### PR TITLE
issue #254 fix slowness on large payloads

### DIFF
--- a/classes/task/upload_student_json_cron.php
+++ b/classes/task/upload_student_json_cron.php
@@ -55,38 +55,74 @@ class upload_student_json_cron extends scheduled_task {
 
         $serviceshortname = 'cursive_json_service';
         $service = $DB->get_record('external_services', ['shortname' => $serviceshortname]);
+        if (!$service) {
+            mtrace('[tiny_cursive] Upload cron skipped: external service not found.');
+            return;
+        }
 
-        $token = '';
         $adminuser = get_admin();
-        $cursivetoken = get_config('tiny_cursive', 'cursivetoken');
+        if (!$adminuser) {
+            mtrace('[tiny_cursive] Upload cron skipped: admin user not found.');
+            return;
+        }
 
-        if (!$cursivetoken) {
-            // Use get_record() instead of get_record_sql() for simpler queries.
-            $token = $DB->get_record(
+        // Use the configured token only when it is a non-empty value; otherwise fall
+        // back to the admin's external web service token.
+        $wstoken = trim((string) get_config('tiny_cursive', 'cursivetoken'));
+        if ($wstoken === '') {
+            $tokenrecord = $DB->get_record(
                 'external_tokens',
                 ['userid' => $adminuser->id, 'externalserviceid' => $service->id],
                 '*',
                 IGNORE_MULTIPLE
             );
-        }
-
-        $wstoken = $cursivetoken ?? $token->token;
-
-        $sql = "SELECT tcf.*
-                FROM {tiny_cursive_files} tcf
-                WHERE tcf.timemodified > tcf.uploaded";
-        $filerecords = $DB->get_records_sql($sql);
-
-        $table = 'tiny_cursive_files';
-        foreach ($filerecords as $filerecord) {
-            $answer = $filerecord->original_content ?? "";
-
-            $uploaded = tiny_cursive_upload_multipart_record($filerecord, $filerecord->filename, $wstoken, $answer);
-            if ($uploaded) {
-                $filerecord->uploaded = strtotime(date('Y-m-d H:i:s'));
-                $DB->update_record($table, $filerecord);
-                $uploaded = false;
+            if ($tokenrecord && !empty($tokenrecord->token)) {
+                $wstoken = $tokenrecord->token;
             }
         }
+
+        if ($wstoken === '') {
+            mtrace('[tiny_cursive] Upload cron skipped: no web service token available.');
+            return;
+        }
+
+        // Select only the lightweight columns needed to drive the loop. The large
+        // content/original_content blobs are loaded per record, just before upload,
+        // to avoid materialising up to $batchsize multi-megabyte rows at once.
+        $batchsize = 200;
+        $sql = "SELECT tcf.id, tcf.userid, tcf.filename, tcf.timemodified, tcf.uploaded
+                FROM {tiny_cursive_files} tcf
+                WHERE tcf.timemodified > tcf.uploaded
+                ORDER BY tcf.timemodified ASC";
+        $filerecords = $DB->get_records_sql($sql, null, 0, $batchsize);
+
+        $table = 'tiny_cursive_files';
+        $successcount = 0;
+        $transientfailurecount = 0;
+        $permanentfailurecount = 0;
+
+        foreach ($filerecords as $filerecord) {
+            // Load the heavy columns only for the record about to be processed.
+            $filerecord->content = $DB->get_field($table, 'content', ['id' => $filerecord->id]);
+            $answer = (string) $DB->get_field($table, 'original_content', ['id' => $filerecord->id]);
+
+            $status = tiny_cursive_upload_multipart_record($filerecord, $filerecord->filename, $wstoken, $answer);
+            if ($status === 'success') {
+                // Update only the timestamp column to avoid rewriting the large content blob.
+                $DB->set_field($table, 'uploaded', time(), ['id' => $filerecord->id]);
+                $successcount++;
+            } else if ($status === 'permanent_failure') {
+                // Mark permanently-failing records as handled so they stop being retried every run.
+                $DB->set_field($table, 'uploaded', $filerecord->timemodified, ['id' => $filerecord->id]);
+                $permanentfailurecount++;
+            } else {
+                $transientfailurecount++;
+            }
+        }
+
+        mtrace(
+            "[tiny_cursive] Upload cron summary - batch size: {$batchsize}, processed: " . count($filerecords) .
+            ", success: {$successcount}, transient failures: {$transientfailurecount}, permanent failures: {$permanentfailurecount}"
+        );
     }
 }

--- a/lib.php
+++ b/lib.php
@@ -300,7 +300,7 @@ function tiny_cursive_myprofile_navigation(core_user\output\myprofile\tree $tree
  * @param string $filenamewithfullpath Full path to the file to upload
  * @param string $wstoken Web service token for authentication
  * @param string $answertext Original submission text
- * @return bool|string Returns response from server or false on failure
+ * @return string One of: success, transient_failure, permanent_failure
  * @throws dml_exception
  */
 function tiny_cursive_upload_multipart_record($filerecord, $filenamewithfullpath, $wstoken, $answertext) {
@@ -308,30 +308,29 @@ function tiny_cursive_upload_multipart_record($filerecord, $filenamewithfullpath
     require_once($CFG->dirroot . '/lib/filelib.php');
 
     $moodleurl = get_config('tiny_cursive', 'host_url');
-    $result    = '';
+    $tempfilepath = null;
 
     try {
         $token      = get_config('tiny_cursive', 'secretkey');
         $remoteurl  = get_config('tiny_cursive', 'python_server') . "/upload_file";
-        $filetosend = '';
+
+        $jsoncontent = json_decode($filerecord->content, true);
+
+        // A payload that cannot be decoded will never succeed, so treat it as permanent.
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            mtrace("[tiny_cursive] Upload permanent failure for record {$filerecord->id}: invalid JSON payload.");
+            return 'permanent_failure';
+        }
 
         $tempfilepath = make_temp_directory('tiny_cursive') . '/' . uniqid('upload_', true);
+        file_put_contents($tempfilepath, json_encode($jsoncontent));
+        $filetosend = new CURLFILE($tempfilepath, 'application/json', 'uploaded.json');
 
-        $jsoncontent  = json_decode($filerecord->content, true);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new moodle_exception('invalidjson', 'tiny_cursive');
-        }
-            file_put_contents($tempfilepath, json_encode($jsoncontent));
-            $filetosend = new CURLFILE($tempfilepath, 'application/json', 'uploaded.json');
-
-            // Ensure the temporary file does not exceed the size limit.
+        // A file over the size limit will always be rejected, so treat it as permanent.
         if (filesize($tempfilepath) > 16 * 1024 * 1024) {
-            unlink($tempfilepath);
-            throw new moodle_exception('filesizelimit', 'tiny_cursive');
+            mtrace("[tiny_cursive] Upload permanent failure for record {$filerecord->id}: payload exceeds 16MB.");
+            return 'permanent_failure';
         }
-
-        echo $remoteurl;
 
         $curl     = new curl();
         $postdata = [
@@ -353,26 +352,41 @@ function tiny_cursive_upload_multipart_record($filerecord, $filenamewithfullpath
             'CURLOPT_RETURNTRANSFER' => true,
         ]);
 
-        $httpcode = $curl->get_info()['http_code'];
+        $httpcode = (int) ($curl->get_info()['http_code'] ?? 0);
 
+        // A transport-level failure may recover on a later run.
         if ($result === false) {
-            echo "File not found: " . $filenamewithfullpath . "\n";
-            echo "cURL Error: " . $curl->error . "\n";
-        } else {
-            echo "\nHTTP Status Code: " . $httpcode . "\n";
-            echo "File Id: " . $filerecord->id . "\n";
-            echo "response: " . $result . "\n";
+            mtrace("[tiny_cursive] Upload transient failure for record {$filerecord->id}: cURL error {$curl->error}.");
+            return 'transient_failure';
         }
 
-        // Remove the temporary file if it was created.
-        if (isset($tempfilepath) && file_exists($tempfilepath)) {
+        if ($httpcode >= 200 && $httpcode < 300) {
+            mtrace("[tiny_cursive] Upload success for record {$filerecord->id} (HTTP {$httpcode}).");
+            return 'success';
+        }
+
+        // Rate limiting and server errors are worth retrying later.
+        if ($httpcode === 429 || $httpcode >= 500 || $httpcode === 0) {
+            mtrace("[tiny_cursive] Upload transient failure for record {$filerecord->id} (HTTP {$httpcode}).");
+            return 'transient_failure';
+        }
+
+        // Other 4xx responses indicate the request itself is bad and will not recover.
+        if ($httpcode >= 400) {
+            mtrace("[tiny_cursive] Upload permanent failure for record {$filerecord->id} (HTTP {$httpcode}).");
+            return 'permanent_failure';
+        }
+
+        mtrace("[tiny_cursive] Upload transient failure for record {$filerecord->id}: unexpected HTTP {$httpcode}.");
+        return 'transient_failure';
+    } catch (moodle_exception $e) {
+        mtrace("[tiny_cursive] Upload permanent failure for record {$filerecord->id}: {$e->getMessage()}");
+        return 'permanent_failure';
+    } finally {
+        if ($tempfilepath !== null && file_exists($tempfilepath)) {
             unlink($tempfilepath);
         }
-    } catch (moodle_exception $e) {
-        echo $e->getMessage();
     }
-
-    return $result;
 }
 
 /**


### PR DESCRIPTION
This fixes issue #254 

+ batch processing
+ Return explicit upload outcomes and stop retrying permanent failures 
+ Add preflight guards and fix token fallback in upload cron 
+ Log an upload cron run summary with per-outcome counts 
+ Avoid rewriting large content blob when updating upload status 
+ Defer loading content blobs until each record is uploaded