### PR TITLE
issue#256 Fix PHPUnit init failure from leaked telemetry task lock

### DIFF
--- a/db/install.php
+++ b/db/install.php
@@ -33,7 +33,12 @@ function xmldb_tiny_cursive_install() {
 
     tiny_cursive_enable_webservice();
     tiny_cursive_enable_webservice_protocol();
-    \core\task\manager::queue_adhoc_task(new post_upgrade_task(), true);
+    // Do not queue the telemetry task under PHPUnit: it makes an outbound HTTP
+    // call that fails in the test environment and leaks its adhoc task lock,
+    // aborting phpunit_util::install_site().
+    if (!PHPUNIT_TEST) {
+        \core\task\manager::queue_adhoc_task(new post_upgrade_task(), true);
+    }
 }
 /**
  * Enable web services in Moodle

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -209,6 +209,11 @@ function xmldb_tiny_cursive_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2026052200, 'tiny', 'cursive');
     }
 
-    \core\task\manager::queue_adhoc_task(new post_upgrade_task(), true);
+    // Do not queue the telemetry task under PHPUnit: it makes an outbound HTTP
+    // call that fails in the test environment and leaks its adhoc task lock,
+    // aborting phpunit_util::install_site().
+    if (!PHPUNIT_TEST) {
+        \core\task\manager::queue_adhoc_task(new post_upgrade_task(), true);
+    }
     return true;
 }


### PR DESCRIPTION
This PR fixes #256 

## **Change:**

Skip queueing the task when PHPUNIT_TEST is set, in both install and upgrade paths. Behaviour for real installs and upgrades is unchanged.

## **Testing:**

1. php admin/tool/phpunit/cli/init.php — completes with exit 0 (previously aborted on the lock error).
2. Full PHPUnit suite runs; no lock-related failure.